### PR TITLE
Fix bug in grep invocation with targetDir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/dist-newstyle/

--- a/Retrie/Options.hs
+++ b/Retrie/Options.hs
@@ -355,11 +355,11 @@ getTargetFiles Options{..} gtss = do
     fps <-
       case buildGrepChain targetDir gts targetFiles of
         Left fs -> return fs
-        Right (stdin, cmd) -> doCmd targetDir verbosity stdin (unwords cmd)
+        Right (stdin, cmd) -> doCmd verbosity stdin (unwords cmd)
 
     let
       r = filter (not . ignore)
-        $ map (normalise . (targetDir </>)) fps
+        $ map normalise fps
     debugPrint verbosity "Files:" r
     return $ HashSet.fromList r
 
@@ -412,11 +412,11 @@ buildGrepChain targetDir gts =
 
     esc s = "'" ++ intercalate "[[:space:]]\\+" (words s) ++ "'"
 
-doCmd :: FilePath -> Verbosity -> String -> String -> IO [FilePath]
-doCmd targetDir verbosity inp shellCmd = do
+doCmd :: Verbosity -> String -> String -> IO [FilePath]
+doCmd verbosity inp shellCmd = do
   debugPrint verbosity "stdin:" [inp]
   debugPrint verbosity "shellCmd:" [shellCmd]
-  let cmd = (shell shellCmd) { cwd = Just targetDir }
+  let cmd = (shell shellCmd)
   (ec, fps, err) <- readCreateProcessWithExitCode cmd inp
   case ec of
     -- A grep exit code 1 means no lines matched, not an actual failure


### PR DESCRIPTION
It does not quite fix #5 
Even with this fix, retrie doesn't apply any changes: 
```
[nix-shell:~/code/ghc-check/src]$ retrie --unfold GHC.Check.Util.guessLibdir -v2
hgIgnorePred: hg: readCreateProcessWithExitCode: runInteractiveProcess: exec: does not exist (No such file or directory)
stdin:

shellCmd:
grep -R --include="*.hs" -l 'infix' /home/pepe/code/ghc-check/src
stdout:

Files:
Imports:
Adding:
[]
guessLibdir
==>
 fromMaybe GHC.Paths.libdir <$> lookupEnv "NIX_GHC_LIBDIR"
hgIgnorePred: hg: readCreateProcessWithExitCode: runInteractiveProcess: exec: does not exist (No such file or directory)
stdin:

shellCmd:
grep -R --include="*.hs" -l 'guessLibdir' /home/pepe/code/ghc-check/src
stdout:
/home/pepe/code/ghc-check/src/GHC/Check/Util.hs
/home/pepe/code/ghc-check/src/GHC/Check.hs

Files:
/home/pepe/code/ghc-check/src/GHC/Check/Util.hs
/home/pepe/code/ghc-check/src/GHC/Check.hs
Processing:
/home/pepe/code/ghc-check/src/GHC/Check.hs
Processing:
/home/pepe/code/ghc-check/src/GHC/Check/Util.hs
Done! 0 lines changed.
```