### PR TITLE
Segregate HSE dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/dist-newstyle/

--- a/Retrie/ExactPrint.hs
+++ b/Retrie/ExactPrint.hs
@@ -4,7 +4,6 @@
 -- LICENSE file in the root directory of this source tree.
 --
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}

--- a/Retrie/ExactPrint.hs
+++ b/Retrie/ExactPrint.hs
@@ -4,6 +4,7 @@
 -- LICENSE file in the root directory of this source tree.
 --
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -45,7 +46,6 @@ module Retrie.ExactPrint
 
 import Control.Exception
 import Control.Monad.State.Lazy hiding (fix)
-import Data.Default as D
 import Data.Function (on)
 import Data.List (transpose)
 import Data.Maybe
@@ -394,8 +394,8 @@ setEntryDP x dp anns = M.alter (Just . f . fromMaybe annNone) k anns
               (c,_):cs -> ann { annPriorComments = (c,dp):cs }
 
 -- Useful for figuring out what annotations should be on something.
-debugParse :: String -> IO ()
-debugParse s = do
+debugParse :: FixityEnv -> String -> IO ()
+debugParse fixityEnv s = do
   writeFile "debug.txt" s
   r <- parseModule "debug.txt"
   case r of
@@ -407,8 +407,8 @@ debugParse s = do
       void $ transformDebug m
   where
     transformDebug =
-      run "fixOneExpr D.def" (fixOneExpr D.def)
-        >=> run "fixOnePat D.def" (fixOnePat D.def)
+      run "fixOneExpr D.def" (fixOneExpr fixityEnv)
+        >=> run "fixOnePat D.def" (fixOnePat fixityEnv)
         >=> run "fixOneEntryExpr" fixOneEntryExpr
         >=> run "fixOneEntryPat" fixOneEntryPat
 

--- a/Retrie/Fixity.hs
+++ b/Retrie/Fixity.hs
@@ -15,19 +15,6 @@ module Retrie.Fixity
   , ppFixityEnv
   ) where
 
--- Note [HSE]
--- GHC's parser parses all operator applications left-associatived,
--- then fixes up the associativity in the renamer, since fixity info isn't
--- known until after name resolution.
---
--- Ideally, we'd run the module through the renamer and let it do its thing,
--- but ghc-exactprint cannot roundtrip renamed modules.
---
--- The next best thing we can do is reassociate the operators ourselves, but
--- we need fixity info. Ideally (#2) we'd rename the module and then extract
--- the info from the FixityEnv. That is a TODO. For now, lets just reuse the
--- list of base package fixities in HSE.
-
 import Retrie.GHC
 
 newtype FixityEnv = FixityEnv
@@ -41,7 +28,7 @@ instance Semigroup FixityEnv where
   (<>) = mappend
 
 instance Monoid FixityEnv where
-  mempty = FixityEnv (mkFsEnv [])
+  mempty = mkFixityEnv []
   -- | 'mappend' for 'FixityEnv' is right-biased
   mappend (FixityEnv e1) (FixityEnv e2) = FixityEnv (plusFsEnv e1 e2)
 

--- a/Retrie/Options.hs
+++ b/Retrie/Options.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleContexts #-}
 -- Copyright (c) Facebook, Inc. and its affiliates.
 --
 -- This source code is licensed under the MIT license found in the
@@ -121,13 +122,13 @@ data Options_ rewrites imports = Options
 -- | Construct default options for the given target directory.
 defaultOptions
   :: (Default rewrites, Default imports)
-  => FilePath -> Options_ rewrites imports
-defaultOptions fp = Options
+  => FixityEnv -> FilePath -> Options_ rewrites imports
+defaultOptions fixityEnv fp = Options
   { additionalImports = D.def
   , colorise = noColor
   , executionMode = ExecRewrite
   , extraIgnores = []
-  , fixityEnv = D.def
+  , fixityEnv = fixityEnv
   , iterateN = 1
   , randomOrder = False
   , rewrites = D.def
@@ -142,7 +143,7 @@ defaultOptions fp = Options
 -- to 'resolveOptions' to get final 'Options'.
 getOptionsParser :: FixityEnv -> IO (Parser ProtoOptions)
 getOptionsParser fEnv = do
-  dOpts <- defaultOptions <$> getCurrentDirectory
+  dOpts <- defaultOptions fEnv <$> getCurrentDirectory
   return $ buildParser dOpts { fixityEnv = fEnv }
 
 buildParser :: ProtoOptions -> Parser ProtoOptions

--- a/Retrie/Options.hs
+++ b/Retrie/Options.hs
@@ -144,7 +144,7 @@ defaultOptions fixityEnv fp = Options
 getOptionsParser :: FixityEnv -> IO (Parser ProtoOptions)
 getOptionsParser fEnv = do
   dOpts <- defaultOptions fEnv <$> getCurrentDirectory
-  return $ buildParser dOpts { fixityEnv = fEnv }
+  return $ buildParser dOpts
 
 buildParser :: ProtoOptions -> Parser ProtoOptions
 buildParser dOpts = do

--- a/Retrie/Options.hs
+++ b/Retrie/Options.hs
@@ -122,13 +122,13 @@ data Options_ rewrites imports = Options
 -- | Construct default options for the given target directory.
 defaultOptions
   :: (Default rewrites, Default imports)
-  => FixityEnv -> FilePath -> Options_ rewrites imports
-defaultOptions fixityEnv fp = Options
+  => FilePath -> Options_ rewrites imports
+defaultOptions fp = Options
   { additionalImports = D.def
   , colorise = noColor
   , executionMode = ExecRewrite
   , extraIgnores = []
-  , fixityEnv = fixityEnv
+  , fixityEnv = mempty
   , iterateN = 1
   , randomOrder = False
   , rewrites = D.def
@@ -143,8 +143,8 @@ defaultOptions fixityEnv fp = Options
 -- to 'resolveOptions' to get final 'Options'.
 getOptionsParser :: FixityEnv -> IO (Parser ProtoOptions)
 getOptionsParser fEnv = do
-  dOpts <- defaultOptions fEnv <$> getCurrentDirectory
-  return $ buildParser dOpts
+  dOpts <- defaultOptions <$> getCurrentDirectory
+  return $ buildParser dOpts{fixityEnv = fEnv}
 
 buildParser :: ProtoOptions -> Parser ProtoOptions
 buildParser dOpts = do

--- a/Retrie/Run.hs
+++ b/Retrie/Run.hs
@@ -20,13 +20,13 @@ module Retrie.Run
 
 import Control.Monad.State.Strict
 import Data.Char
-import Data.Default
 import Data.List
 import Data.Monoid
 import System.Console.ANSI
 
 import Retrie.CPP
 import Retrie.ExactPrint
+import Retrie.Fixity
 import Retrie.GHC
 import Retrie.Monad
 import Retrie.Options
@@ -48,15 +48,16 @@ import Retrie.Util
 -- >   return $ apply rr
 --
 -- To run the script, compile the program and execute it.
-runScript :: (Options -> IO (Retrie ())) -> IO ()
-runScript f = runScriptWithModifiedOptions (\opts -> (opts,) <$> f opts)
+runScript :: FixityEnv -> (Options -> IO (Retrie ())) -> IO ()
+runScript fixityEnv f =
+  runScriptWithModifiedOptions fixityEnv (\opts -> (opts,) <$> f opts)
 
 -- | Define a custom refactoring script and run it with modified options.
 -- This is the same as 'runScript', but the returned 'Options' will be used
 -- during rewriting.
-runScriptWithModifiedOptions :: (Options -> IO (Options, Retrie ())) -> IO ()
-runScriptWithModifiedOptions f = do
-  opts <- parseOptions def
+runScriptWithModifiedOptions :: FixityEnv -> (Options -> IO (Options, Retrie ())) -> IO ()
+runScriptWithModifiedOptions fixityEnv f = do
+  opts <- parseOptions fixityEnv
   (opts', retrie) <- f opts
   execute opts' retrie
 

--- a/Retrie/Run.hs
+++ b/Retrie/Run.hs
@@ -26,7 +26,6 @@ import System.Console.ANSI
 
 import Retrie.CPP
 import Retrie.ExactPrint
-import Retrie.Fixity
 import Retrie.GHC
 import Retrie.Monad
 import Retrie.Options
@@ -48,16 +47,15 @@ import Retrie.Util
 -- >   return $ apply rr
 --
 -- To run the script, compile the program and execute it.
-runScript :: FixityEnv -> (Options -> IO (Retrie ())) -> IO ()
-runScript fixityEnv f =
-  runScriptWithModifiedOptions fixityEnv (\opts -> (opts,) <$> f opts)
+runScript :: (Options -> IO (Retrie ())) -> IO ()
+runScript f = runScriptWithModifiedOptions (\opts -> (opts,) <$> f opts)
 
 -- | Define a custom refactoring script and run it with modified options.
 -- This is the same as 'runScript', but the returned 'Options' will be used
 -- during rewriting.
-runScriptWithModifiedOptions :: FixityEnv -> (Options -> IO (Options, Retrie ())) -> IO ()
-runScriptWithModifiedOptions fixityEnv f = do
-  opts <- parseOptions fixityEnv
+runScriptWithModifiedOptions :: (Options -> IO (Options, Retrie ())) -> IO ()
+runScriptWithModifiedOptions f = do
+  opts <- parseOptions mempty
   (opts', retrie) <- f opts
   execute opts' retrie
 

--- a/bin/Main.hs
+++ b/bin/Main.hs
@@ -7,7 +7,7 @@
 module Main (main) where
 
 import Control.Monad
-import Data.Default
+import Fixity
 import Retrie
 import Retrie.Debug
 import Retrie.Options
@@ -15,7 +15,7 @@ import Retrie.Run
 
 main :: IO ()
 main = do
-  opts@Options{..} <- parseOptions def
+  opts@Options{..} <- parseOptions defaultFixityEnv
   doRoundtrips fixityEnv targetDir roundtrips
   unless (null rewrites) $ do
     when (verbosity > Silent) $ do

--- a/bin/Main.hs
+++ b/bin/Main.hs
@@ -16,7 +16,7 @@ import Retrie.Run
 main :: IO ()
 main = do
   opts@Options{..} <- parseOptions defaultFixityEnv
-  doRoundtrips fixityEnv targetDir roundtrips
+  doRoundtrips defaultFixityEnv targetDir roundtrips
   unless (null rewrites) $ do
     when (verbosity > Silent) $ do
       putStrLn "Adding:"

--- a/demo/Main.hs
+++ b/demo/Main.hs
@@ -25,8 +25,8 @@ import Fixity
 -- +quux = fooNew (error "invalid argument: quux")
 --
 main :: IO ()
-main = runScript defaultFixityEnv $ \opts -> do
-  [rewrite] <- parseRewrites opts [Adhoc "forall arg. fooOld arg = fooNew arg"]
+main = runScript $ \opts -> do
+  [rewrite] <- parseRewrites opts{fixityEnv=defaultFixityEnv} [Adhoc "forall arg. fooOld arg = fooNew arg"]
   return $ apply [setRewriteTransformer stringToFooArg rewrite]
 
 argMapping :: [(FastString, String)]

--- a/demo/Main.hs
+++ b/demo/Main.hs
@@ -8,6 +8,7 @@
 module Main where
 
 import Retrie
+import Fixity
 
 -- | A script for rewriting calls to a function that takes a string to be
 -- calls to a new function that takes an enumeration. See the README for
@@ -24,7 +25,7 @@ import Retrie
 -- +quux = fooNew (error "invalid argument: quux")
 --
 main :: IO ()
-main = runScript $ \opts -> do
+main = runScript defaultFixityEnv $ \opts -> do
   [rewrite] <- parseRewrites opts [Adhoc "forall arg. fooOld arg = fooNew arg"]
   return $ apply [setRewriteTransformer stringToFooArg rewrite]
 

--- a/hse/Fixity.hs
+++ b/hse/Fixity.hs
@@ -1,0 +1,45 @@
+-- Copyright (c) Facebook, Inc. and its affiliates.
+--
+-- This source code is licensed under the MIT license found in the
+-- LICENSE file in the root directory of this source tree.
+--
+module Fixity
+  ( defaultFixityEnv
+  ) where
+
+-- Note [HSE]
+-- GHC's parser parses all operator applications left-associatived,
+-- then fixes up the associativity in the renamer, since fixity info isn't
+-- known until after name resolution.
+--
+-- Ideally, we'd run the module through the renamer and let it do its thing,
+-- but ghc-exactprint cannot roundtrip renamed modules.
+--
+-- The next best thing we can do is reassociate the operators ourselves, but
+-- we need fixity info. Ideally (#2) we'd rename the module and then extract
+-- the info from the FixityEnv. That is a TODO. For now, lets just reuse the
+-- list of base package fixities in HSE.
+import qualified Language.Haskell.Exts as HSE
+
+import Retrie.Fixity
+import Retrie.GHC
+
+defaultFixityEnv :: FixityEnv
+defaultFixityEnv = mkFixityEnv $ map hseToGHC HSE.baseFixities
+
+hseToGHC :: HSE.Fixity -> (FastString, (FastString, Fixity))
+hseToGHC (HSE.Fixity assoc p nm) = (fs, (fs, Fixity (SourceText nm') p (dir assoc)))
+  where
+    dir (HSE.AssocNone _)  = InfixN
+    dir (HSE.AssocLeft _)  = InfixL
+    dir (HSE.AssocRight _) = InfixR
+
+    nm' = case nm of
+      HSE.Qual _ _ n -> nameStr n
+      HSE.UnQual _ n -> nameStr n
+      _             -> "SpecialCon"
+
+    fs = mkFastString nm'
+
+    nameStr (HSE.Ident _ s)  = s
+    nameStr (HSE.Symbol _ s) = s

--- a/retrie.cabal
+++ b/retrie.cabal
@@ -83,7 +83,6 @@ library
     filepath >= 1.4.2 && < 1.5,
     ghc >= 8.4 && < 8.12,
     ghc-exactprint >= 0.6.2 && < 0.7,
-    haskell-src-exts >= 1.23.0 && < 1.24,
     mtl >= 2.2.2 && < 2.3,
     optparse-applicative >= 0.15.1 && < 0.16,
     process >= 1.6.3 && < 1.7,
@@ -94,27 +93,40 @@ library
     unordered-containers >= 0.2.10 && < 0.3
   default-language: Haskell2010
 
+Flag BuildExecutable
+  Description: build the retrie executable
+  Default: True
+
 executable retrie
+  if flag(BuildExecutable)
+    Buildable: True
+  else
+    Buildable: False
   main-is:
     Main.hs
-  hs-source-dirs: bin
-  other-modules:
+  hs-source-dirs: bin hse
+  other-modules: Fixity
   GHC-Options: -Wall
   build-depends:
     retrie,
     base >= 4.11 && < 4.15,
-    data-default
+    haskell-src-exts >= 1.23.0 && < 1.24
   default-language: Haskell2010
 
 executable demo
+  if flag(BuildExecutable)
+    Buildable: True
+  else
+    Buildable: False
   main-is:
     Main.hs
-  hs-source-dirs: demo
-  other-modules:
+  hs-source-dirs: demo hse
+  other-modules: Fixity
   GHC-Options: -Wall
   build-depends:
     retrie,
-    base >= 4.11 && < 4.15
+    base >= 4.11 && < 4.15,
+    haskell-src-exts >= 1.23.0 && < 1.24
   default-language: Haskell2010
 
 test-suite test
@@ -127,13 +139,14 @@ test-suite test
     Demo,
     Dependent,
     Exclude,
+    Fixity,
     Golden,
     GroundTerms,
     Ignore,
     ParseQualified,
     Targets,
     Util
-  hs-source-dirs: tests
+  hs-source-dirs: tests hse
   default-language: Haskell2010
   GHC-Options: -Wall
   build-depends:
@@ -147,6 +160,7 @@ test-suite test
     filepath,
     ghc >= 8.4 && < 8.12,
     ghc-paths,
+    haskell-src-exts >= 1.23.0 && < 1.24,
     mtl,
     optparse-applicative,
     process,

--- a/tests/AllTests.hs
+++ b/tests/AllTests.hs
@@ -8,8 +8,8 @@
 {-# LANGUAGE RecordWildCards #-}
 module AllTests (allTests) where
 
-import Data.Default
 import Data.Maybe
+import Fixity
 import Retrie
 import Retrie.Options
 import System.Environment
@@ -29,7 +29,7 @@ import Targets
 
 allTests :: Verbosity -> IO Test
 allTests rtVerbosity = do
-  p <- getOptionsParser def
+  p <- getOptionsParser defaultFixityEnv
   rtDir <-
     fromMaybe (dropFileName __FILE__ </> "inputs")
       <$> lookupEnv "RETRIEINPUTSDIR"

--- a/tests/Exclude.hs
+++ b/tests/Exclude.hs
@@ -8,6 +8,7 @@
 module Exclude (excludeTest) where
 
 import Data.List (isPrefixOf, stripPrefix)
+import Fixity
 import Retrie
 import Retrie.Options
 import System.FilePath
@@ -43,7 +44,7 @@ excludeTest v = TestLabel "exclude path prefixes" $
         $ nonExcludedPathsAreIncluded relfilepaths
 
 optionsWithExtraIgnores :: FilePath -> Verbosity -> Options
-optionsWithExtraIgnores target v = (defaultOptions target)
+optionsWithExtraIgnores target v = (defaultOptions defaultFixityEnv target)
   { extraIgnores = excludedPaths
   , verbosity = v
   }

--- a/tests/Exclude.hs
+++ b/tests/Exclude.hs
@@ -31,7 +31,7 @@ excludeTest :: Verbosity -> Test
 excludeTest v = TestLabel "exclude path prefixes" $
   TestCase $ do
     withFakeHgRepo [] allFiles $ \dir -> do
-      let opts = optionsWithExtraIgnores dir v
+      let opts = optionsWithDefaultFixities $ optionsWithExtraIgnores dir v
       filepaths <- getTargetFiles opts []
       assertBool (unlines ["Expected ", show excludedPaths,
         "to be excluded, these were included : ", show filepaths])
@@ -44,10 +44,13 @@ excludeTest v = TestLabel "exclude path prefixes" $
         $ nonExcludedPathsAreIncluded relfilepaths
 
 optionsWithExtraIgnores :: FilePath -> Verbosity -> Options
-optionsWithExtraIgnores target v = (defaultOptions defaultFixityEnv target)
+optionsWithExtraIgnores target v = (defaultOptions target)
   { extraIgnores = excludedPaths
   , verbosity = v
   }
+
+optionsWithDefaultFixities :: Options -> Options
+optionsWithDefaultFixities opts = opts { fixityEnv = defaultFixityEnv }
 
 -- Check that filepaths with prefixes in the excluded list are excluded
 excludedPathsAreExcluded :: [FilePath] -> Bool

--- a/tests/GroundTerms.hs
+++ b/tests/GroundTerms.hs
@@ -11,9 +11,9 @@ module GroundTerms
 
 import Control.Monad
 import Control.Monad.IO.Class
-import Data.Default
 import qualified Data.HashSet as HashSet
 import Data.Text (Text)
+import Fixity
 import Retrie.CPP
 import Retrie.ExactPrint
 import Retrie.GroundTerms
@@ -62,8 +62,8 @@ gtTest lbl contents specs expected expectedCmds =
 
     rrs <-
       parseRewriteSpecs
-        (\_ -> parseCPP (parseContent def "Test") contents)
-        def
+        (\_ -> parseCPP (parseContent defaultFixityEnv "Test") contents)
+        defaultFixityEnv
         specs
     let gtss = map groundTerms rrs
 
@@ -81,8 +81,8 @@ gtTest lbl contents specs expected expectedCmds =
 
 getFocusTests :: IO [Test]
 getFocusTests = do
-  rrs1 <- parseAdhocs def ["forall xs. or (map isSpace xs) = any isSpace xs"]
-  rrs2 <- parseAdhocs def ["forall f g xs. map f (map g xs) = map (f . g) xs"]
+  rrs1 <- parseAdhocs defaultFixityEnv ["forall xs. or (map isSpace xs) = any isSpace xs"]
+  rrs2 <- parseAdhocs defaultFixityEnv ["forall f g xs. map f (map g xs) = map (f . g) xs"]
   let
     -- compare hashsets to avoid ordering issues
     terms = HashSet.fromList $ map groundTerms rrs1

--- a/tests/Targets.hs
+++ b/tests/Targets.hs
@@ -63,5 +63,5 @@ allFiles =
   ] ++ retrieTargetFiles
 
 optionsWithTargetFiles :: FilePath -> [FilePath] -> Options
-optionsWithTargetFiles dir targets = (defaultOptions defaultFixityEnv dir)
+optionsWithTargetFiles dir targets = (defaultOptions dir)
   { targetFiles = map (dir </>) targets }

--- a/tests/Targets.hs
+++ b/tests/Targets.hs
@@ -10,6 +10,7 @@ module Targets
 
 import qualified Data.HashSet as HashSet
 import Data.List
+import Fixity
 import Retrie.GroundTerms
 import Retrie.Options
 import System.FilePath
@@ -62,5 +63,5 @@ allFiles =
   ] ++ retrieTargetFiles
 
 optionsWithTargetFiles :: FilePath -> [FilePath] -> Options
-optionsWithTargetFiles dir targets = (defaultOptions dir)
+optionsWithTargetFiles dir targets = (defaultOptions defaultFixityEnv dir)
   { targetFiles = map (dir </>) targets }


### PR DESCRIPTION
The HSE dependency is unnecessary if the caller provides a parse function that takes care of operator associativity.