### PR TITLE
Remove dependency on xargs

### DIFF
--- a/Retrie/Options.hs
+++ b/Retrie/Options.hs
@@ -467,18 +467,13 @@ buildGrepChain targetDir gts filesGiven =
     filterStart gs = unwords ["grep", "-l", esc gs] 
     filterChain gs = [ unwords ["grep", "-l", esc gt] | gt <- gs ]
 
-    esc s = "'" ++ intercalate "[[:space:]]\\+" (words s) ++ "'"
-
--- Notes on Windows compatability
--- The way System.Process handles stdin is currently incompatible with xargs in many ways:
---
--- - newlines that are written as `\r\n`so after splitting grep sees `...\r` and can't find the file.
---       both System.Process and grep automatically use '\r\n' for newlines
--- - paths like "C:\Users\.." lose the backslashes so grep sees `C:Users...` and can't find the file
--- - paths aren't quoted so paths with spaces break
--- - ...
---
--- Instead, move the loop into haskell land and invoke grep multiple times
+    esc s = "'" ++ intercalate "[[:space:]]\\+" (words $ escChars s) ++ "'"
+    escChars = concatMap escChar
+    escChar c
+      | c `elem` magicChars = "\\" <> [c]
+      | otherwise  = [c]
+    magicChars :: [Char]
+    magicChars = "*?[#˜=%\\"
 
 
 

--- a/tests/GroundTerms.hs
+++ b/tests/GroundTerms.hs
@@ -23,6 +23,7 @@ import Retrie.Rewrites
 import Retrie.Types
 import Retrie.Universe
 import Test.HUnit
+import Retrie.Options (GrepCommands(..))
 
 groundTermsTest :: Test
 groundTermsTest = TestLabel "ground terms" $ TestList
@@ -30,17 +31,17 @@ groundTermsTest = TestLabel "ground terms" $ TestList
       ""
       [Adhoc "forall f g xs. map f (map g xs) = map (f . g) xs"]
       [["map"]]
-      [["grep -R --include=\"*.hs\" -l 'map' ~/si_sigma"]]
+      [GrepCommands [] ["grep -R --include=\"*.hs\" -l 'map' ~/si_sigma"]]
   , gtTest "isSpace"
       ""
       [Adhoc "forall xs. or (map isSpace xs) = any isSpace xs"]
       [["or", "map isSpace"]]
-      [["grep -R --include=\"*.hs\" -l 'or' ~/si_sigma", "grep -l 'map[[:space:]]\\+isSpace'"]]
+      [GrepCommands [] ["grep -R --include=\"*.hs\" -l 'or' ~/si_sigma", "grep -l 'map[[:space:]]\\+isSpace'"]]
   , gtTest "MyType"
       "type MyType a = MyOtherType a"
       [TypeForward "Test.MyType"]
       [["MyType"]]
-      [["grep -R --include=\"*.hs\" -l 'MyType' ~/si_sigma"]]
+      [GrepCommands [] ["grep -R --include=\"*.hs\" -l 'MyType' ~/si_sigma"]]
   ]
 
 gtTest
@@ -48,7 +49,7 @@ gtTest
   -> Text
   -> [RewriteSpec]
   -> [[String]]
-  -> [[String]]
+  -> [GrepCommands]
   -> Test
 gtTest lbl contents specs expected expectedCmds =
   TestLabel ("groundTerms: " ++ lbl) $ TestCase $ do
@@ -73,7 +74,7 @@ gtTest lbl contents specs expected expectedCmds =
 
     forM_ (zip gtss expectedCmds) $ \(gts, expectedCmd) ->
       case buildGrepChain "~/si_sigma" gts [] of
-        ([], c) ->
+        c ->
           assertEqual "buildGrepChain did not give expected command"
             expectedCmd
             c

--- a/tests/GroundTerms.hs
+++ b/tests/GroundTerms.hs
@@ -30,17 +30,17 @@ groundTermsTest = TestLabel "ground terms" $ TestList
       ""
       [Adhoc "forall f g xs. map f (map g xs) = map (f . g) xs"]
       [["map"]]
-      [("", "grep -R --include=\"*.hs\" -l 'map' ~/si_sigma")]
+      [["grep -R --include=\"*.hs\" -l 'map' ~/si_sigma"]]
   , gtTest "isSpace"
       ""
       [Adhoc "forall xs. or (map isSpace xs) = any isSpace xs"]
       [["or", "map isSpace"]]
-      [("", "grep -R --include=\"*.hs\" -l 'or' ~/si_sigma | xargs grep -l 'map[[:space:]]\\+isSpace'")]
+      [["grep -R --include=\"*.hs\" -l 'or' ~/si_sigma", "grep -l 'map[[:space:]]\\+isSpace'"]]
   , gtTest "MyType"
       "type MyType a = MyOtherType a"
       [TypeForward "Test.MyType"]
       [["MyType"]]
-      [("", "grep -R --include=\"*.hs\" -l 'MyType' ~/si_sigma")]
+      [["grep -R --include=\"*.hs\" -l 'MyType' ~/si_sigma"]]
   ]
 
 gtTest
@@ -48,7 +48,7 @@ gtTest
   -> Text
   -> [RewriteSpec]
   -> [[String]]
-  -> [(String, String)]
+  -> [[String]]
   -> Test
 gtTest lbl contents specs expected expectedCmds =
   TestLabel ("groundTerms: " ++ lbl) $ TestCase $ do
@@ -73,11 +73,11 @@ gtTest lbl contents specs expected expectedCmds =
 
     forM_ (zip gtss expectedCmds) $ \(gts, expectedCmd) ->
       case buildGrepChain "~/si_sigma" gts [] of
-        Left _ -> assertFailure "gtTest: Left"
-        Right (i, c) ->
+        ([], c) ->
           assertEqual "buildGrepChain did not give expected command"
             expectedCmd
-            (i, unwords c)
+            c
+        _ -> assertFailure "gtTest: Should not have paths"
 
 getFocusTests :: IO [Test]
 getFocusTests = do

--- a/tests/GroundTerms.hs
+++ b/tests/GroundTerms.hs
@@ -23,35 +23,44 @@ import Retrie.Rewrites
 import Retrie.Types
 import Retrie.Universe
 import Test.HUnit
-import Retrie.Options (GrepCommands(..))
 
 groundTermsTest :: Test
 groundTermsTest = TestLabel "ground terms" $ TestList
   [ gtTest "map"
       ""
+      []
       [Adhoc "forall f g xs. map f (map g xs) = map (f . g) xs"]
       [["map"]]
-      [GrepCommands [] ["grep -R --include=\"*.hs\" -l 'map' ~/si_sigma"]]
+      [GrepCommands [] ["grep -R --include=\"*.hs\" -l 'map' '~/si_sigma'"]]
   , gtTest "isSpace"
       ""
+      []
       [Adhoc "forall xs. or (map isSpace xs) = any isSpace xs"]
       [["or", "map isSpace"]]
-      [GrepCommands [] ["grep -R --include=\"*.hs\" -l 'or' ~/si_sigma", "grep -l 'map[[:space:]]\\+isSpace'"]]
+      [GrepCommands [] ["grep -R --include=\"*.hs\" -l 'or' '~/si_sigma'", "grep -l 'map[[:space:]]\\+isSpace'"]]
   , gtTest "MyType"
       "type MyType a = MyOtherType a"
+      []
       [TypeForward "Test.MyType"]
       [["MyType"]]
-      [GrepCommands [] ["grep -R --include=\"*.hs\" -l 'MyType' ~/si_sigma"]]
+      [GrepCommands [] ["grep -R --include=\"*.hs\" -l 'MyType' '~/si_sigma'"]]
+  , gtTest "isSpace with file"
+      ""
+      ["Test.hs", "Test2.hs"]
+      [Adhoc "forall xs. or (map isSpace xs) = any isSpace xs"]
+      [["or", "map isSpace"]]
+      [GrepCommands ["Test.hs", "Test2.hs"] ["grep -l 'or'", "grep -l 'map[[:space:]]\\+isSpace'"]]
   ]
 
 gtTest
   :: String
   -> Text
+  -> [FilePath]
   -> [RewriteSpec]
   -> [[String]]
   -> [GrepCommands]
   -> Test
-gtTest lbl contents specs expected expectedCmds =
+gtTest lbl contents targFiles specs expected expectedCmds =
   TestLabel ("groundTerms: " ++ lbl) $ TestCase $ do
     -- since we 'zip' below
     assertEqual "length of specs and expected ground terms"
@@ -73,12 +82,9 @@ gtTest lbl contents specs expected expectedCmds =
       (HashSet.fromList gtss) -- compare hashsets to avoid ordering issues
 
     forM_ (zip gtss expectedCmds) $ \(gts, expectedCmd) ->
-      case buildGrepChain "~/si_sigma" gts [] of
-        c ->
           assertEqual "buildGrepChain did not give expected command"
             expectedCmd
-            c
-        _ -> assertFailure "gtTest: Should not have paths"
+            (buildGrepChain "~/si_sigma" gts targFiles)
 
 getFocusTests :: IO [Test]
 getFocusTests = do

--- a/tests/Targets.hs
+++ b/tests/Targets.hs
@@ -28,7 +28,7 @@ targetedWithGroundTerms =
       gts = [HashSet.fromList ["Groundterm"]]
       targetFps = retrieTargetFiles
       -- 'withFakeHgRepo' creates every file with its own name as the contents
-      expectedFps = ["targeted/Groundterm.hs"]
+      expectedFps = ["targeted" </> "Groundterm.hs"]
 
 assertFileListEqual
   :: [FilePath]


### PR DESCRIPTION
Windows support currently is blocked on a series of escaping issues caused by xargs, as discussed in #21 . This pull request replaces the dependency on xargs by a series of separate grep calls.

The good news is that this does allow usage from haskell-language-server on Windows. The bad news is that direct calls to the retrie executable still break non deterministically. Sometimes retrie works correctly, frequently it errors with errors like

    C:\sr\snapshots\6bf6c8f4\pkgdb\package.cache.lock: openBinaryFile: resource busy (file is locked)

Occasionally the output gets mangled badly as well, though the underlying error message appears to be the same

    C:\\Users\Name\ACp:p\Dsart\as\nLaopcsahlo\tPsr\o6gbrfa6mcs8\fs4t\apckkg\dxb8\6p_a6c4k-awgien.dcoawcsh\eg.hlco-c8k.:1 0o.p4e\nlBiibn\apraycFkialgee:. croensfo.udr\cpea cbkuasgy e .(cfaiclhee .ilso clko:c koepde)n

I'm reasonably sure that these errors aren't my fault but I'd be thankful if someone with access to a linux system could check that the test suite didn't regress on linux.