### PR TITLE
escape single quote in pattern when calling grep

### DIFF
--- a/Retrie/Options.hs
+++ b/Retrie/Options.hs
@@ -465,13 +465,17 @@ buildGrepChain targetDir gts filesGiven = GrepCommands {initialFileSet=filesGive
 
     hsExtension = "\"*.hs\""
 
-    esc s = "'" ++ intercalate "[[:space:]]\\+" (words $ escChars s) ++ "'"
+    esc s = osquote $ intercalate "[[:space:]]\\+" (words $ escChars s)
     escChars = concatMap escChar
     escChar c
       | c `elem` magicChars = "\\" <> [c]
       | otherwise  = [c]
     magicChars :: [Char]
     magicChars = "*?[#˜=%\\"
+
+    osquote s = "'" ++ concatMap escapeQuote s ++ "'"
+      where escapeQuote '\'' = "'\"'\"'"
+            escapeQuote c = [c]
 
 
 type CommandLine = String


### PR DESCRIPTION
It's not sufficient to escape characters that are special to grep.
One must also escape the single quote that is used to quote the
pattern to the shell.

To expose the issue in the original code, try something on this order:

    retrie --dry-run --adhoc "forall x . backendNeedn'tLink x = not (backendNeedsLink x)"