### PR TITLE
Allow default extensions to be provided on the command line

### DIFF
--- a/Retrie/Debug.hs
+++ b/Retrie/Debug.hs
@@ -13,6 +13,7 @@ module Retrie.Debug
 import Options.Applicative
 import System.FilePath
 
+import Retrie.Types (Extension)
 import Retrie.CPP
 import Retrie.ExactPrint
 import Retrie.Fixity
@@ -29,11 +30,11 @@ parseRoundtrips = concat <$> traverse many
       <> help "Roundtrip file through ghc-exactprint only.")
   ]
 
-doRoundtrips :: LibDir -> FixityEnv -> FilePath -> [RoundTrip] -> IO ()
-doRoundtrips libdir fixities targetDir = mapM_ $ \ (RoundTrip doFix fp) -> do
+doRoundtrips :: [Extension] -> LibDir -> FixityEnv -> FilePath -> [RoundTrip] -> IO ()
+doRoundtrips exts libdir fixities targetDir = mapM_ $ \ (RoundTrip doFix fp) -> do
   let path = targetDir </> fp
   cpp <-
     if doFix
-    then parseCPPFile (parseContent libdir fixities) path
-    else parseCPPFile (parseContentNoFixity libdir) path
+    then parseCPPFile (parseContent exts libdir fixities) path
+    else parseCPPFile (parseContentNoFixity exts libdir) path
   writeFile path $ printCPP [] cpp

--- a/Retrie/Rewrites/Patterns.hs
+++ b/Retrie/Rewrites/Patterns.hs
@@ -25,14 +25,15 @@ import Retrie.Universe
 import Retrie.Util
 
 patternSynonymsToRewrites
-  :: LibDir
+  :: [Extension]
+  -> LibDir
   -> [(FastString, Direction)]
   -> AnnotatedModule
   -> IO (UniqFM FastString [Rewrite Universe])
-patternSynonymsToRewrites libdir specs am = fmap astA $ transformA am $ \(L _ m) -> do
+patternSynonymsToRewrites exts libdir specs am = fmap astA $ transformA am $ \(L _ m) -> do
   let
     fsMap = uniqBag specs
-  imports <- getImports libdir RightToLeft (hsmodName m)
+  imports <- getImports exts libdir RightToLeft (hsmodName m)
   rrs <- sequence
       [ do
           patRewrite <- mkPatRewrite dir imports nm params lrhs

--- a/Retrie/Run.hs
+++ b/Retrie/Run.hs
@@ -88,7 +88,7 @@ run libdir writeFn wrapper opts@Options{..} r = do
   fps <- getTargetFiles opts (getGroundTerms r)
   forFn opts fps $ \ fp -> wrapper $ do
     debugPrint verbosity "Processing:" [fp]
-    p <- trySync $ parseCPPFile (parseContent libdir fixityEnv) fp
+    p <- trySync $ parseCPPFile (parseContent defaultExtensions libdir fixityEnv) fp
     case p of
       Left ex -> do
         when (verbosity > Silent) $ print ex

--- a/Retrie/Types.hs
+++ b/Retrie/Types.hs
@@ -45,6 +45,7 @@ module Retrie.Types
   , RewriterResult(..)
   , ParentPrec(..)
   , Context(..)
+  , Extension(..)
   ) where
 
 import Control.Monad.IO.Class
@@ -53,6 +54,7 @@ import Data.Bifunctor
 import qualified Data.IntMap.Strict as I
 import Data.Data hiding (Fixity)
 import Data.Maybe
+import GHC.LanguageExtensions (Extension(..))
 
 import Retrie.AlphaEnv
 import Retrie.ExactPrint

--- a/bin/Main.hs
+++ b/bin/Main.hs
@@ -18,7 +18,7 @@ main :: IO ()
 main = do
   let libdir = GHC.Paths.libdir
   opts@Options{..} <- parseOptions libdir defaultFixityEnv
-  doRoundtrips libdir fixityEnv targetDir roundtrips
+  doRoundtrips defaultExtensions libdir fixityEnv targetDir roundtrips
   unless (null rewrites) $ do
     when (verbosity > Silent) $ do
       putStrLn "Adding:"

--- a/retrie.cabal
+++ b/retrie.cabal
@@ -84,6 +84,7 @@ library
     directory >= 1.3.1 && < 1.4,
     filepath >= 1.4.2 && < 1.5,
     ghc >= 9.2,
+    ghc-boot,
     ghc-exactprint >= 1.4.0 && < 1.5,
     list-t >= 1.0.4 && < 1.1,
     mtl >= 2.2.2 && < 2.3,

--- a/tests/CPP.hs
+++ b/tests/CPP.hs
@@ -254,7 +254,7 @@ cppForkTest CPPTest{..} = TestLabel ("cpp fork: " ++ name) $ TestCase $ do
 
 roundTripTest :: CPPTest -> Test
 roundTripTest CPPTest{..} = TestLabel ("roundtrip: " ++ name) $ TestCase $ do
-  r <- trySync $ parseCPP (parseContentNoFixity GHC.Paths.libdir "roundTripTest") code
+  r <- trySync $ parseCPP (parseContentNoFixity [] GHC.Paths.libdir "roundTripTest") code
   case r of
     Left msg -> assertFailure (show msg)
     Right cpp -> assertEqual "cpp did not roundtrip correctly"

--- a/tests/GroundTerms.hs
+++ b/tests/GroundTerms.hs
@@ -72,8 +72,8 @@ gtTest libdir lbl contents targFiles specs expected expectedCmds =
       (length expectedCmds)
 
     rrs <-
-      parseRewriteSpecs libdir
-        (\_ -> parseCPP (parseContent libdir defaultFixityEnv "Test") contents)
+      parseRewriteSpecs [] libdir
+        (\_ -> parseCPP (parseContent [] libdir defaultFixityEnv "Test") contents)
         defaultFixityEnv
         specs
     let gtss = map groundTerms rrs
@@ -89,8 +89,8 @@ gtTest libdir lbl contents targFiles specs expected expectedCmds =
 
 getFocusTests :: LibDir -> IO [Test]
 getFocusTests libdir = do
-  rrs1 <- parseAdhocs libdir defaultFixityEnv ["forall xs. or (map isSpace xs) = any isSpace xs"]
-  rrs2 <- parseAdhocs libdir defaultFixityEnv ["forall f g xs. map f (map g xs) = map (f . g) xs"]
+  rrs1 <- parseAdhocs [] libdir defaultFixityEnv ["forall xs. or (map isSpace xs) = any isSpace xs"]
+  rrs2 <- parseAdhocs [] libdir defaultFixityEnv ["forall f g xs. map f (map g xs) = map (f . g) xs"]
   let
     -- compare hashsets to avoid ordering issues
     terms = HashSet.fromList $ map groundTerms rrs1


### PR DESCRIPTION
This PR allows you to provide a list of `--extension`s to enable on the command line, and threads them through to the required parsers.

As a follow-up, it might be nice to extract the extensions from the `.cabal` file.