### PR TITLE
Update to GHC 9.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,11 +9,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ghc: ['9.4.2', '9.2.4']
+        ghc: ['9.4.1', '9.2.4']
 
     steps:
     - uses: actions/checkout@v2
-    - uses: haskell/actions/setup@v1
+    - uses: haskell/actions/setup@v2.0.1
       with:
         ghc-version: ${{ matrix.ghc }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ghc: ['9.2.1']
+        ghc: ['9.4.2', '9.2.4']
 
     steps:
     - uses: actions/checkout@v2

--- a/Retrie/CPP.hs
+++ b/Retrie/CPP.hs
@@ -27,7 +27,8 @@ import Debug.Trace
 import Retrie.ExactPrint
 import Retrie.GHC
 import Retrie.Replace
-#if MIN_VERSION_ghc(9, 4, 0)
+#if __GLASGOW_HASKELL__ < 904
+#else
 import GHC.Types.PkgQual
 #endif
 
@@ -346,16 +347,17 @@ eqImportDecl x y =
   && ((==) `on` ideclQualified) x y
   && ((==) `on` ideclAs) x y
   && ((==) `on` ideclHiding) x y
-#if MIN_VERSION_ghc(9, 4, 0)
-  && (eqRawPkgQual `on` ideclPkgQual) x y
-#else
+#if __GLASGOW_HASKELL__ < 904
   && ((==) `on` ideclPkgQual) x y
+#else
+  && (eqRawPkgQual `on` ideclPkgQual) x y
 #endif
   && ((==) `on` ideclSource) x y
   && ((==) `on` ideclSafe) x y
   -- intentionally leave out ideclImplicit and ideclSourceSrc
   -- former doesn't matter for this check, latter is prone to whitespace issues
-#if MIN_VERSION_ghc(9, 4, 0)
+#if __GLASGOW_HASKELL__ < 904
+#else
   where
     eqRawPkgQual NoRawPkgQual NoRawPkgQual = True
     eqRawPkgQual NoRawPkgQual (RawPkgQual _) = False

--- a/Retrie/CPP.hs
+++ b/Retrie/CPP.hs
@@ -3,6 +3,7 @@
 -- This source code is licensed under the MIT license found in the
 -- LICENSE file in the root directory of this source tree.
 --
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 module Retrie.CPP
@@ -26,6 +27,9 @@ import Debug.Trace
 import Retrie.ExactPrint
 import Retrie.GHC
 import Retrie.Replace
+#if MIN_VERSION_ghc(9, 4, 0)
+import GHC.Types.PkgQual
+#endif
 
 -- Note [CPP]
 -- We can't just run the pre-processor on files and then rewrite them, because
@@ -342,8 +346,19 @@ eqImportDecl x y =
   && ((==) `on` ideclQualified) x y
   && ((==) `on` ideclAs) x y
   && ((==) `on` ideclHiding) x y
+#if MIN_VERSION_ghc(9, 4, 0)
+  && (eqRawPkgQual `on` ideclPkgQual) x y
+#else
   && ((==) `on` ideclPkgQual) x y
+#endif
   && ((==) `on` ideclSource) x y
   && ((==) `on` ideclSafe) x y
   -- intentionally leave out ideclImplicit and ideclSourceSrc
   -- former doesn't matter for this check, latter is prone to whitespace issues
+#if MIN_VERSION_ghc(9, 4, 0)
+  where
+    eqRawPkgQual NoRawPkgQual NoRawPkgQual = True
+    eqRawPkgQual NoRawPkgQual (RawPkgQual _) = False
+    eqRawPkgQual (RawPkgQual _) NoRawPkgQual = False
+    eqRawPkgQual (RawPkgQual s) (RawPkgQual s') = s == s'
+#endif

--- a/Retrie/Context.hs
+++ b/Retrie/Context.hs
@@ -61,7 +61,7 @@ updateContext c i =
     -- In left child, prec is 10, so HsApp child will NOT get paren'd
     -- In right child, prec is 11, so every child gets paren'd (unless atomic)
     updExp (OpApp _ _ op _) = c { ctxtParentPrec = HasPrec $ lookupOp op (ctxtFixityEnv c) }
-    updExp (HsLet _ lbs _) = addInScope neverParen $ collectLocalBinders CollNoDictBinders lbs
+    updExp (HsLet _ _ lbs _ _) = addInScope neverParen $ collectLocalBinders CollNoDictBinders lbs
     updExp _ = neverParen
 
     updType :: HsType GhcPs -> Context

--- a/Retrie/Context.hs
+++ b/Retrie/Context.hs
@@ -61,10 +61,10 @@ updateContext c i =
     -- In left child, prec is 10, so HsApp child will NOT get paren'd
     -- In right child, prec is 11, so every child gets paren'd (unless atomic)
     updExp (OpApp _ _ op _) = c { ctxtParentPrec = HasPrec $ lookupOp op (ctxtFixityEnv c) }
-#if MIN_VERSION_ghc(9, 4, 0)
-    updExp (HsLet _ _ lbs _ _) = addInScope neverParen $ collectLocalBinders CollNoDictBinders lbs
-#else
+#if __GLASGOW_HASKELL__ < 904
     updExp (HsLet _ lbs _) = addInScope neverParen $ collectLocalBinders CollNoDictBinders lbs
+#else
+    updExp (HsLet _ _ lbs _ _) = addInScope neverParen $ collectLocalBinders CollNoDictBinders lbs
 #endif
     updExp _ = neverParen
 

--- a/Retrie/Context.hs
+++ b/Retrie/Context.hs
@@ -61,7 +61,11 @@ updateContext c i =
     -- In left child, prec is 10, so HsApp child will NOT get paren'd
     -- In right child, prec is 11, so every child gets paren'd (unless atomic)
     updExp (OpApp _ _ op _) = c { ctxtParentPrec = HasPrec $ lookupOp op (ctxtFixityEnv c) }
+#if MIN_VERSION_ghc(9, 4, 0)
     updExp (HsLet _ _ lbs _ _) = addInScope neverParen $ collectLocalBinders CollNoDictBinders lbs
+#else
+    updExp (HsLet _ lbs _) = addInScope neverParen $ collectLocalBinders CollNoDictBinders lbs
+#endif
     updExp _ = neverParen
 
     updType :: HsType GhcPs -> Context

--- a/Retrie/ExactPrint.hs
+++ b/Retrie/ExactPrint.hs
@@ -257,12 +257,12 @@ swapEntryDPT a b = do
 -- Compatibility module with ghc-exactprint
 
 parseContentNoFixity :: Parsers.LibDir -> FilePath -> String -> IO AnnotatedModule
-parseContentNoFixity libdir fp str = do
+parseContentNoFixity libdir fp str = join $ Parsers.withDynFlags libdir $ \dflags -> do
   r <- Parsers.parseModuleFromString libdir fp str
   case r of
     Left msg -> do
 #if MIN_VERSION_ghc(9, 4, 0)
-      fail $ show msg
+      fail $ showSDoc dflags $ ppr msg
 #elif MIN_VERSION_ghc(9, 0, 0)
       fail $ show $ bagToList msg
 #else
@@ -317,7 +317,7 @@ parseHelper :: (ExactPrint a)
 parseHelper libdir fp parser str = join $ Parsers.withDynFlags libdir $ \dflags ->
   case parser dflags fp str of
 #if MIN_VERSION_ghc(9, 4, 0)
-    Left msg -> throwIO $ ErrorCall (show msg)
+    Left msg -> throwIO $ ErrorCall (showSDoc dflags $ ppr msg)
 #elif MIN_VERSION_ghc(9, 0, 0)
     Left errBag -> throwIO $ ErrorCall (show $ bagToList errBag)
 #else

--- a/Retrie/ExactPrint.hs
+++ b/Retrie/ExactPrint.hs
@@ -261,10 +261,12 @@ parseContentNoFixity libdir fp str = do
   r <- Parsers.parseModuleFromString libdir fp str
   case r of
     Left msg -> do
-#if __GLASGOW_HASKELL__ < 810
+#if MIN_VERSION_ghc(9, 4, 0)
       fail $ show msg
-#else
+#elif MIN_VERSION_ghc(9, 0, 0)
       fail $ show $ bagToList msg
+#else
+      fail $ show msg
 #endif
     Right m -> return $ unsafeMkA (makeDeltaAst m) 0
 
@@ -314,10 +316,12 @@ parseHelper :: (ExactPrint a)
   => Parsers.LibDir -> FilePath -> Parsers.Parser a -> String -> IO (Annotated a)
 parseHelper libdir fp parser str = join $ Parsers.withDynFlags libdir $ \dflags ->
   case parser dflags fp str of
-#if __GLASGOW_HASKELL__ < 810
-    Left (_, msg) -> throwIO $ ErrorCall msg
-#else
+#if MIN_VERSION_ghc(9, 4, 0)
+    Left msg -> throwIO $ ErrorCall (show msg)
+#elif MIN_VERSION_ghc(9, 0, 0)
     Left errBag -> throwIO $ ErrorCall (show $ bagToList errBag)
+#else
+    Left (_, msg) -> throwIO $ ErrorCall msg
 #endif
     Right x -> return $ unsafeMkA (makeDeltaAst x) 0
 

--- a/Retrie/ExactPrint.hs
+++ b/Retrie/ExactPrint.hs
@@ -261,12 +261,12 @@ parseContentNoFixity libdir fp str = join $ Parsers.withDynFlags libdir $ \dflag
   r <- Parsers.parseModuleFromString libdir fp str
   case r of
     Left msg -> do
-#if MIN_VERSION_ghc(9, 4, 0)
-      fail $ showSDoc dflags $ ppr msg
-#elif MIN_VERSION_ghc(9, 0, 0)
+#if __GLASGOW_HASKELL__ < 900
+      fail $ show msg
+#elif __GLASGOW_HASKELL__ < 904
       fail $ show $ bagToList msg
 #else
-      fail $ show msg
+      fail $ showSDoc dflags $ ppr msg
 #endif
     Right m -> return $ unsafeMkA (makeDeltaAst m) 0
 
@@ -316,12 +316,12 @@ parseHelper :: (ExactPrint a)
   => Parsers.LibDir -> FilePath -> Parsers.Parser a -> String -> IO (Annotated a)
 parseHelper libdir fp parser str = join $ Parsers.withDynFlags libdir $ \dflags ->
   case parser dflags fp str of
-#if MIN_VERSION_ghc(9, 4, 0)
-    Left msg -> throwIO $ ErrorCall (showSDoc dflags $ ppr msg)
-#elif MIN_VERSION_ghc(9, 0, 0)
+#if __GLASGOW_HASKELL__ < 900
+    Left (_, msg) -> throwIO $ ErrorCall msg
+#elif __GLASGOW_HASKELL__ < 904
     Left errBag -> throwIO $ ErrorCall (show $ bagToList errBag)
 #else
-    Left (_, msg) -> throwIO $ ErrorCall msg
+    Left msg -> throwIO $ ErrorCall (showSDoc dflags $ ppr msg)
 #endif
     Right x -> return $ unsafeMkA (makeDeltaAst x) 0
 

--- a/Retrie/ExactPrint/Annotated.hs
+++ b/Retrie/ExactPrint/Annotated.hs
@@ -87,13 +87,12 @@ instance Default ast => Default (Annotated ast) where
   def = Annotated D.def 0
 
 instance (Data ast, Monoid ast) => Semigroup (Annotated ast) where
-  (<>) = mappend
+  a1 <> (Annotated ast2 _) =
+    runIdentity $ transformA a1 $ \ ast1 ->
+      mappend ast1 <$> return ast2
 
 instance (Data ast, Monoid ast) => Monoid (Annotated ast) where
   mempty = Annotated mempty 0
-  mappend a1 (Annotated ast2 _) =
-    runIdentity $ transformA a1 $ \ ast1 ->
-      mappend ast1 <$> return ast2
 
 -- | Construct an 'Annotated'.
 -- This should really only be used in the parsing functions, hence the scary name.

--- a/Retrie/Expr.hs
+++ b/Retrie/Expr.hs
@@ -1,4 +1,4 @@
--- CopAAyright (c) Facebook, Inc. and its affiliates.
+-- Copyright (c) Facebook, Inc. and its affiliates.
 --
 -- This source code is licensed under the MIT license found in the
 -- LICENSE file in the root directory of this source tree.

--- a/Retrie/Expr.hs
+++ b/Retrie/Expr.hs
@@ -272,8 +272,8 @@ patToExpr orig = case dLPat orig of
 #if MIN_VERSION_ghc(9, 4, 0)
     go (ParPat an _ p' _) = do
       p <- patToExpr p'
-      let tokLP = L NoTokenLoc HsTok
-          tokRP = L NoTokenLoc HsTok
+      let tokLP = L (TokenLoc (EpaDelta (SameLine 0) [])) HsTok
+          tokRP = L (TokenLoc (EpaDelta (SameLine 0) [])) HsTok
       lift $ mkLocA (SameLine 1) (HsPar an tokLP p tokRP)
 #else
     go (ParPat an p') = do
@@ -409,8 +409,8 @@ parenifyP Context{..} p@(L _ pat)
   | IsLhs <- ctxtParentPrec
   , needed pat =
 #if MIN_VERSION_ghc(9, 4, 0)
-    let tokLP = L NoTokenLoc HsTok
-        tokRP = L NoTokenLoc HsTok
+    let tokLP = L (TokenLoc (EpaDelta (SameLine 0) [])) HsTok
+        tokRP = L (TokenLoc (EpaDelta (SameLine 0) [])) HsTok
      in mkParen' (getEntryDP p) (\an -> ParPat an tokLP (setEntryDP p (SameLine 0)) tokRP)
 #else
     mkParen' (getEntryDP p) (\an -> ParPat an (setEntryDP p (SameLine 0)))

--- a/Retrie/Expr.hs
+++ b/Retrie/Expr.hs
@@ -1,4 +1,4 @@
--- Copyright (c) Facebook, Inc. and its affiliates.
+-- CopAAyright (c) Facebook, Inc. and its affiliates.
 --
 -- This source code is licensed under the MIT license found in the
 -- LICENSE file in the root directory of this source tree.
@@ -138,6 +138,13 @@ mkLams vs e = do
 mkLet :: Monad m => HsLocalBinds GhcPs -> LHsExpr GhcPs -> TransformT m (LHsExpr GhcPs)
 mkLet EmptyLocalBinds{} e = return e
 mkLet lbs e = do
+#if MIN_VERSION_ghc(9, 4, 0)
+  an <- mkEpAnn (DifferentLine 1 5) NoEpAnns
+  let tokLet = L (TokenLoc (EpaDelta (SameLine 0) [])) HsTok
+      tokIn = L (TokenLoc (EpaDelta (DifferentLine 1 1) [])) HsTok
+  le <- mkLocA (SameLine 1) $ HsLet an tokLet lbs tokIn e
+  return le
+#else
   an <- mkEpAnn (DifferentLine 1 5)
                 (AnnsLet {
                    alLet = EpaDelta (SameLine 0) [],
@@ -145,7 +152,7 @@ mkLet lbs e = do
                  })
   le <- mkLocA (SameLine 1) $ HsLet an lbs e
   return le
-
+#endif
 
 
 mkApps :: MonadIO m => LHsExpr GhcPs -> [LHsExpr GhcPs] -> TransformT m (LHsExpr GhcPs)

--- a/Retrie/Expr.hs
+++ b/Retrie/Expr.hs
@@ -327,12 +327,13 @@ precedence _        _                = Nothing
 parenify
   :: Monad m => Context -> LHsExpr GhcPs -> TransformT m (LHsExpr GhcPs)
 parenify Context{..} le@(L _ e)
-  | needed ctxtParentPrec (precedence ctxtFixityEnv e) && needsParens e =
 #if MIN_VERSION_ghc(9, 4, 0)
-    let tokLP = L NoTokenLoc HsTok
-        tokRP = L NoTokenLoc HsTok
+  | needed ctxtParentPrec (precedence ctxtFixityEnv e) && needsParens e = do
+    let tokLP = L (TokenLoc (EpaDelta (SameLine 0) [])) HsTok
+        tokRP = L (TokenLoc (EpaDelta (SameLine 0) [])) HsTok
      in mkParen' (getEntryDP le) (\an -> HsPar an tokLP (setEntryDP le (SameLine 0)) tokRP)
 #else
+  | needed ctxtParentPrec (precedence ctxtFixityEnv e) && needsParens e =
     mkParen' (getEntryDP le) (\an -> HsPar an (setEntryDP le (SameLine 0)))
 #endif
   | otherwise = return le

--- a/Retrie/Expr.hs
+++ b/Retrie/Expr.hs
@@ -14,6 +14,7 @@ module Retrie.Expr
   , grhsToExpr
   , mkApps
   , mkConPatIn
+  , mkEpAnn
   , mkHsAppsTy
   , mkLams
   , mkLet

--- a/Retrie/Fixity.hs
+++ b/Retrie/Fixity.hs
@@ -22,12 +22,10 @@ newtype FixityEnv = FixityEnv
 
 instance Semigroup FixityEnv where
   -- | 'mappend' for 'FixityEnv' is right-biased
-  (<>) = mappend
+  (FixityEnv e1) <> (FixityEnv e2) = FixityEnv (plusFsEnv e1 e2)
 
 instance Monoid FixityEnv where
   mempty = mkFixityEnv []
-  -- | 'mappend' for 'FixityEnv' is right-biased
-  mappend (FixityEnv e1) (FixityEnv e2) = FixityEnv (plusFsEnv e1 e2)
 
 lookupOp :: LHsExpr GhcPs -> FixityEnv -> Fixity
 lookupOp (L _ e) | Just n <- varRdrName e = lookupOpRdrName n

--- a/Retrie/Fixity.hs
+++ b/Retrie/Fixity.hs
@@ -43,7 +43,7 @@ extendFixityEnv l (FixityEnv env) =
   FixityEnv $ extendFsEnvList env [ (fs, p) | p@(fs,_) <- l ]
 
 ppFixityEnv :: FixityEnv -> String
-ppFixityEnv = unlines . map ppFixity . eltsUFM . unFixityEnv
+ppFixityEnv = unlines . map ppFixity . nonDetEltsUFM . unFixityEnv
   where
     ppFixity (fs, Fixity _ p d) = unwords
       [ case d of

--- a/Retrie/GHC.hs
+++ b/Retrie/GHC.hs
@@ -15,6 +15,7 @@ module Retrie.GHC
   , module GHC.Hs.Expr
   , module GHC.Parser.Annotation
   , module GHC.Parser.Errors.Ppr
+  , module GHC.Plugins
   , module GHC.Types.Basic
   , module GHC.Types.Error
   , module GHC.Types.Fixity
@@ -27,6 +28,7 @@ module Retrie.GHC
   , module GHC.Types.Unique.FM
   , module GHC.Types.Unique.Set
   , module GHC.Unit.Module.Name
+  , module GHC.Utils.Outputable
   ) where
 
 import GHC
@@ -39,6 +41,7 @@ import GHC.Hs
 import GHC.Hs.Expr
 import GHC.Parser.Annotation
 import GHC.Parser.Errors.Ppr
+import GHC.Plugins (showSDoc)
 import GHC.Types.Basic hiding (EP)
 import GHC.Types.Error
 import GHC.Types.Fixity
@@ -51,6 +54,7 @@ import GHC.Types.Unique
 import GHC.Types.Unique.FM
 import GHC.Types.Unique.Set
 import GHC.Unit.Module.Name
+import GHC.Utils.Outputable (Outputable (ppr))
 
 import Data.Bifunctor (second)
 import Data.Maybe

--- a/Retrie/PatternMap/Instances.hs
+++ b/Retrie/PatternMap/Instances.hs
@@ -373,13 +373,13 @@ instance PatternMap EMap where
         m { emOpApp = mAlter env vs o (toA (mAlter env vs l (toA (mAlter env vs r f)))) (emOpApp m) }
 #if MIN_VERSION_ghc(9, 4, 0)
       go (RecordCon _ v fs) =
-       let a :: A (ListMap RFMap a)
-           a = toA (mAlter env vs undefined f) -- (fieldsToRdrNames $ rec_flds fs)
-        in
-         m { emRecordCon = mAlter env vs (unLoc v) a (emRecordCon m) }
+        m { emRecordCon = mAlter env vs (unLoc v :: RdrName) (toA (mAlter env vs (rec_flds fs) f)) (emRecordCon m) }
       go (RecordUpd _ e' fs) =
-       let a :: A Double
-           a = toA undefined -- (toA (mAlter env vs (fieldsToRdrNamesUpd fs) f))
+       let fieldsToRdrNamesUpd (Left xs) =
+             error "abc"
+           fieldsToRdrNamesUpd (Right x) = error "abc"
+           -- a = (toA (mAlter env vs (fieldsToRdrNamesUpd fs) f))
+           a = toA (mAlter env vs (fieldsToRdrNamesUpd fs) f)
         in
          m { emRecordUpd = mAlter env vs e' a (emRecordUpd m) }
 #else

--- a/Retrie/PatternMap/Instances.hs
+++ b/Retrie/PatternMap/Instances.hs
@@ -8,12 +8,14 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE ViewPatterns #-}
+-- NOTE: This was needed for GHC 9.4 due to
+-- type Key RFMap = LocatedA (HsRecField GhcPS (LocatedA (HsExpr GhcPs)))
 {-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE RankNTypes #-}
 module Retrie.PatternMap.Instances where
 
 import Control.Monad

--- a/Retrie/Rewrites.hs
+++ b/Retrie/Rewrites.hs
@@ -25,10 +25,10 @@ import System.FilePath
 import Retrie.CPP
 import Retrie.ExactPrint
 import Retrie.Fixity
-#if MIN_VERSION_ghc(9, 4, 0)
-import Retrie.GHC hiding (Pattern)
-#else
+#if __GLASGOW_HASKELL__ < 904
 import Retrie.GHC
+#else
+import Retrie.GHC hiding (Pattern)
 #endif
 import Retrie.Rewrites.Function
 import Retrie.Rewrites.Patterns

--- a/Retrie/Rewrites.hs
+++ b/Retrie/Rewrites.hs
@@ -25,7 +25,11 @@ import System.FilePath
 import Retrie.CPP
 import Retrie.ExactPrint
 import Retrie.Fixity
+#if MIN_VERSION_ghc(9, 4, 0)
+import Retrie.GHC hiding (Pattern)
+#else
 import Retrie.GHC
+#endif
 import Retrie.Rewrites.Function
 import Retrie.Rewrites.Patterns
 import Retrie.Rewrites.Rules

--- a/Retrie/Rewrites/Function.hs
+++ b/Retrie/Rewrites/Function.hs
@@ -82,7 +82,11 @@ irrefutablePat = go . unLoc
     go VarPat{} = True
     go (LazyPat _ p) = irrefutablePat p
     go (AsPat _ _ p) = irrefutablePat p
+#if MIN_VERSION_ghc(9, 4, 0)
+    go (ParPat _ _ p _) = irrefutablePat p
+#else
     go (ParPat _ p) = irrefutablePat p
+#endif
     go (BangPat _ p) = irrefutablePat p
     go _ = False
 

--- a/Retrie/Rewrites/Function.hs
+++ b/Retrie/Rewrites/Function.hs
@@ -82,10 +82,10 @@ irrefutablePat = go . unLoc
     go VarPat{} = True
     go (LazyPat _ p) = irrefutablePat p
     go (AsPat _ _ p) = irrefutablePat p
-#if MIN_VERSION_ghc(9, 4, 0)
-    go (ParPat _ _ p _) = irrefutablePat p
-#else
+#if __GLASGOW_HASKELL__ < 904
     go (ParPat _ p) = irrefutablePat p
+#else
+    go (ParPat _ _ p _) = irrefutablePat p
 #endif
     go (BangPat _ p) = irrefutablePat p
     go _ = False

--- a/Retrie/Rewrites/Patterns.hs
+++ b/Retrie/Rewrites/Patterns.hs
@@ -97,7 +97,13 @@ asPat patName params = do
     convertField :: (Monad m) => RecordPatSynField GhcPs
                       -> TransformT m (LHsRecField GhcPs (LPat GhcPs))
     convertField RecordPatSynField{..} = do
-#if MIN_VERSION_ghc(9, 4, 0)
+#if __GLASGOW_HASKELL__ < 904
+      hsRecFieldLbl <- mkLoc $ recordPatSynField
+      hsRecFieldArg <- mkVarPat recordPatSynPatVar
+      let hsRecPun = False
+      let hsRecFieldAnn = noAnn
+      mkLocA (SameLine 0) HsRecField{..}
+#else
       s <- uniqueSrcSpanT
       an <- mkEpAnn (SameLine 0) NoEpAnns
       let srcspan = SrcSpanAnn an s
@@ -106,12 +112,6 @@ asPat patName params = do
       let hfbPun = False
           hfbAnn = noAnn
       mkLocA (SameLine 0) HsFieldBind{..}
-#else
-      hsRecFieldLbl <- mkLoc $ recordPatSynField
-      hsRecFieldArg <- mkVarPat recordPatSynPatVar
-      let hsRecPun = False
-      let hsRecFieldAnn = noAnn
-      mkLocA (SameLine 0) HsRecField{..}
 #endif
 
 mkExpRewrite

--- a/Retrie/Rewrites/Patterns.hs
+++ b/Retrie/Rewrites/Patterns.hs
@@ -97,12 +97,22 @@ asPat patName params = do
     convertField :: (Monad m) => RecordPatSynField GhcPs
                       -> TransformT m (LHsRecField GhcPs (LPat GhcPs))
     convertField RecordPatSynField{..} = do
+#if MIN_VERSION_ghc(9, 4, 0)
+      s <- uniqueSrcSpanT
+      an <- mkEpAnn (SameLine 0) NoEpAnns
+      let srcspan = SrcSpanAnn an s
+          hfbLHS = L srcspan recordPatSynField
+      hfbRHS <- mkVarPat recordPatSynPatVar
+      let hfbPun = False
+          hfbAnn = noAnn
+      mkLocA (SameLine 0) HsFieldBind{..}
+#else
       hsRecFieldLbl <- mkLoc $ recordPatSynField
       hsRecFieldArg <- mkVarPat recordPatSynPatVar
       let hsRecPun = False
       let hsRecFieldAnn = noAnn
       mkLocA (SameLine 0) HsRecField{..}
-
+#endif
 
 mkExpRewrite
   :: Direction

--- a/Retrie/Substitution.hs
+++ b/Retrie/Substitution.hs
@@ -22,7 +22,7 @@ newtype Substitution = Substitution (UniqFM FastString (FastString, HoleVal))
 -- See Note [Why not RdrNames?] for explanation of use of FastString
 
 instance Show Substitution where
-  show (Substitution m) = show (eltsUFM m)
+  show (Substitution m) = show (nonDetEltsUFM m)
 
 -- | Sum type of possible substitution values.
 data HoleVal

--- a/retrie.cabal
+++ b/retrie.cabal
@@ -83,8 +83,6 @@ library
     data-default >= 0.7.1 && < 0.8,
     directory >= 1.3.1 && < 1.4,
     filepath >= 1.4.2 && < 1.5,
-    ghc >= 9.4,
-    ghc-exactprint >= 1.6.0 && < 1.7,
     list-t >= 1.0.4 && < 1.1,
     mtl >= 2.2.2 && < 2.3,
     optparse-applicative >= 0.15.1 && < 0.17,
@@ -94,6 +92,14 @@ library
     text >= 1.2.3 && < 2.1,
     transformers >= 0.5.5 && < 0.6,
     unordered-containers >= 0.2.10 && < 0.3
+  if impl (ghc >= 9.4) && (impl (ghc < 9.5))
+    build-depends:
+       ghc == 9.4.*,
+       ghc-exactprint >= 1.6.0 && < 1.7
+  if impl (ghc >= 9.2) && (impl (ghc < 9.3))
+    build-depends:
+      ghc == 9.2.*,
+      ghc-exactprint < 1.6.0 && > 1.4.0
   default-language: Haskell2010
 
 Flag BuildExecutable

--- a/retrie.cabal
+++ b/retrie.cabal
@@ -77,14 +77,14 @@ library
   build-depends:
     ansi-terminal >= 0.10.3 && < 0.12,
     async >= 2.2.2 && < 2.3,
-    base >= 4.11 && < 4.17,
+    base >= 4.11 && < 4.18,
     bytestring >= 0.10.8 && < 0.12,
     containers >= 0.5.11 && < 0.7,
     data-default >= 0.7.1 && < 0.8,
     directory >= 1.3.1 && < 1.4,
     filepath >= 1.4.2 && < 1.5,
-    ghc >= 9.2,
-    ghc-exactprint >= 1.4.0 && < 1.6,
+    ghc >= 9.4,
+    ghc-exactprint >= 1.6.0 && < 1.7,
     list-t >= 1.0.4 && < 1.1,
     mtl >= 2.2.2 && < 2.3,
     optparse-applicative >= 0.15.1 && < 0.17,
@@ -112,7 +112,7 @@ executable retrie
   GHC-Options: -Wall
   build-depends:
     retrie,
-    base >= 4.11 && < 4.17,
+    base >= 4.11 && < 4.18,
     haskell-src-exts >= 1.23.0 && < 1.24,
     ghc-paths
   default-language: Haskell2010
@@ -129,7 +129,7 @@ executable demo-retrie
   GHC-Options: -Wall
   build-depends:
     retrie,
-    base >= 4.11 && < 4.17,
+    base >= 4.11 && < 4.18,
     haskell-src-exts >= 1.23.0 && < 1.24,
     ghc-paths
   default-language: Haskell2010


### PR DESCRIPTION
This updates `retrie` for compatibility with GHC 9.4, which is necessary for improved GHC 9.4 support from `haskell-language-server`.

HLS PR based on these changes: https://github.com/haskell/haskell-language-server/pull/3317