### PR TITLE
Set `buildable: false` for unsupported ghc

### DIFF
--- a/retrie.cabal
+++ b/retrie.cabal
@@ -92,14 +92,17 @@ library
     text >= 1.2.3 && < 2.1,
     transformers >= 0.5.5 && < 0.6,
     unordered-containers >= 0.2.10 && < 0.3
-  if impl (ghc >= 9.4) && (impl (ghc < 9.5))
+  if impl (ghc >= 9.4) && impl (ghc < 9.5)
     build-depends:
-       ghc == 9.4.*,
-       ghc-exactprint >= 1.6.0 && < 1.7
-  if impl (ghc >= 9.2) && (impl (ghc < 9.3))
-    build-depends:
-      ghc == 9.2.*,
-      ghc-exactprint < 1.6.0 && > 1.4.0
+      ghc == 9.4.*,
+      ghc-exactprint >= 1.6.0 && < 1.7
+  else
+    if impl (ghc >= 9.2) && impl (ghc < 9.3)
+      build-depends:
+        ghc == 9.2.*,
+        ghc-exactprint < 1.6.0 && > 1.4.0
+    else
+      buildable: false
   default-language: Haskell2010
 
 Flag BuildExecutable

--- a/retrie.cabal
+++ b/retrie.cabal
@@ -102,7 +102,7 @@ library
         ghc == 9.2.*,
         ghc-exactprint < 1.6.0 && > 1.4.0
     else
-      buildable: false
+      buildable: False
   default-language: Haskell2010
 
 Flag BuildExecutable


### PR DESCRIPTION
Currently the retrieval `1.2.1` in hackage shadows versions that work with older compilers.  The cabal planner selects this version (`1.2.1`) because it does not think it needs the `ghc` library at all when making a plan for older versions of ghc.

I think we may also need to deprecate `1.2.1` in hackage (as I don't know if this change can be made as a hackage revision).  Perhaps another option might be:

```
  build-depends: ghc >= 9.2
  if impl (ghc >= 9.4) && impl (ghc < 9.5)
    build-depends:
       ghc == 9.4.*,
       ghc-exactprint >= 1.6.0 && < 1.7
  else
    if impl (ghc >= 9.2) && impl (ghc < 9.3)
      build-depends:
        ghc == 9.2.*,
        ghc-exactprint < 1.6.0 && > 1.4.0
```