### PR TITLE
Simplify build depends and bump version

### DIFF
--- a/retrie.cabal
+++ b/retrie.cabal
@@ -4,7 +4,7 @@
 -- LICENSE file in the root directory of this source tree.
 --
 name: retrie
-version: 1.2.1
+version: 1.2.1.1
 synopsis: A powerful, easy-to-use codemodding tool for Haskell.
 homepage: https://github.com/facebookincubator/retrie
 bug-reports: https://github.com/facebookincubator/retrie/issues
@@ -83,6 +83,8 @@ library
     data-default >= 0.7.1 && < 0.8,
     directory >= 1.3.1 && < 1.4,
     filepath >= 1.4.2 && < 1.5,
+    ghc >= 9.2 && < 9.5,
+    ghc-exactprint >= 1.5.0 && < 1.7,
     list-t >= 1.0.4 && < 1.1,
     mtl >= 2.2.2 && < 2.3,
     optparse-applicative >= 0.15.1 && < 0.17,
@@ -92,14 +94,6 @@ library
     text >= 1.2.3 && < 2.1,
     transformers >= 0.5.5 && < 0.6,
     unordered-containers >= 0.2.10 && < 0.3
-  if impl (ghc >= 9.4) && (impl (ghc < 9.5))
-    build-depends:
-       ghc == 9.4.*,
-       ghc-exactprint >= 1.6.0 && < 1.7
-  if impl (ghc >= 9.2) && (impl (ghc < 9.3))
-    build-depends:
-      ghc == 9.2.*,
-      ghc-exactprint < 1.6.0 && > 1.4.0
   default-language: Haskell2010
 
 Flag BuildExecutable


### PR DESCRIPTION
This is another take at #51 noting that ghc-exactprint already pins the ghc version, which is enough for the Cabal solver to construct a working plan