### PR TITLE
Regression tests for redundant parens after type rewriting

### DIFF
--- a/tests/inputs/Types.test
+++ b/tests/inputs/Types.test
@@ -23,6 +23,25 @@
  type Pointless a = a
  type Fn a b = a -> b
  
+ data Meh = Meh
+-  { entryKey :: Pointless (Int -> String)
+-  , entryVal :: Fn Int String
++  { entryKey :: (Int -> String)
++  , entryVal :: (Int -> String)
+   }
+ 
+-getKey :: Meh -> Pointless (Int -> String)
++getKey :: Meh -> (Int -> String)
+ getKey m x = entryKey m x
+ 
+-setKey :: Pointless (Int -> String) -> Meh -> Meh
++setKey :: (Int -> String) -> Meh -> Meh
+ setKey m k = m{ entryKey = k }
+ 
+-errorKey :: Fn Int String
++errorKey :: (Int -> String)
+ errorKey = getKey undefined
+ 
 -blah :: IO (Fn Int Bool)
 +blah :: IO (Int -> Bool)
  blah = return (> 0)


### PR DESCRIPTION
We see redundant parens around an function result type after rewriting, this doesn't produce invalid code, but it is not as nice as it could be. We add tests to show some examples, but maybe improve this in the future changes.