### PR TITLE
Improve parenthesization on expr and type

### DIFF
--- a/Retrie/Types.hs
+++ b/Retrie/Types.hs
@@ -91,7 +91,6 @@ data Context = Context
 data ParentPrec
   = HasPrec Fixity -- ^ Parent has precedence info.
   | IsLhs      -- ^ We are a pattern in a left-hand-side
-  | IsHsAppsTy -- ^ Parent is HsAppsTy
   | NeverParen -- ^ Based on parent, we should never add parentheses.
 
 ------------------------------------------------------------------------

--- a/tests/inputs/Combined.test
+++ b/tests/inputs/Combined.test
@@ -46,7 +46,7 @@
  
  baz2 :: Int
 -baz2 = foo * bar
-+baz2 = (3 + 4) * 5 `quot` foo
++baz2 = (3 + 4) * (5 `quot` foo)
  
  quux :: Int -> Int
 -quux x = foo * x

--- a/tests/inputs/Parens.test
+++ b/tests/inputs/Parens.test
@@ -29,7 +29,7 @@
  
  baz2 :: Int
 -baz2 = foo `quot` bar
-+baz2 = (3 + 4) `quot` 5 `quot` foo
++baz2 = (3 + 4) `quot` (5 `quot` foo)
  
  quux :: Int -> Int
 -quux x = foo * x
@@ -76,7 +76,7 @@
  
  shl4 :: Int -> Int
 -shl4 n = n `shiftL` shl1 2
-+shl4 n = n `shiftL` 2 `shiftL` 1
++shl4 n = n `shiftL` (2 `shiftL` 1)
  
  mixedDirs :: Int
 -mixedDirs = shl1 3 ^ shl1 4
@@ -86,19 +86,19 @@
  type MaybeInt = Maybe Int
  
 -($!) :: Fn (a -> b) (a -> b)
-+($!) :: ((a -> b) -> (a -> b))
++($!) :: (a -> b) -> a -> b
  f $! x = f (x)
  
 -(&!) :: a -> Fn (a -> b) b
-+(&!) :: a -> ((a -> b) -> b)
++(&!) :: a -> (a -> b) -> b
  (&!) x f = (f) x
  
 -konst :: b -> Fn a b
-+konst :: b -> (a -> b)
++konst :: b -> a -> b
  konst x _ = x
  
 -noop :: Fn a a
-+noop :: (a -> a)
++noop :: a -> a
  noop x = x
  
 -idMaybeInt :: MaybeInt -> MaybeInt

--- a/tests/inputs/Types.test
+++ b/tests/inputs/Types.test
@@ -26,12 +26,12 @@
  data Meh = Meh
 -  { entryKey :: Pointless (Int -> String)
 -  , entryVal :: Fn Int String
-+  { entryKey :: (Int -> String)
-+  , entryVal :: (Int -> String)
++  { entryKey :: Int -> String
++  , entryVal :: Int -> String
    }
  
 -getKey :: Meh -> Pointless (Int -> String)
-+getKey :: Meh -> (Int -> String)
++getKey :: Meh -> Int -> String
  getKey m x = entryKey m x
  
 -setKey :: Pointless (Int -> String) -> Meh -> Meh
@@ -39,7 +39,7 @@
  setKey m k = m{ entryKey = k }
  
 -errorKey :: Fn Int String
-+errorKey :: (Int -> String)
++errorKey :: Int -> String
  errorKey = getKey undefined
  
 -blah :: IO (Fn Int Bool)


### PR DESCRIPTION
We noticed redudant parens for types, and actually, we can even have bugs for missing parens for expr. We refactor and improved the parenthesization on expr and type to address both problems.

Closes #66
Closes #67