### PR TITLE
Do not unparen the immediate HsPar around sections

### DIFF
--- a/Retrie/Expr.hs
+++ b/Retrie/Expr.hs
@@ -358,12 +358,17 @@ getUnparened = mkT unparen `extT` unparenT `extT` unparenP
 
 -- TODO: what about comments?
 unparen :: LHsExpr GhcPs -> LHsExpr GhcPs
+unparen expr = case expr of
 #if __GLASGOW_HASKELL__ < 904
-unparen (L _ (HsPar _ e)) = e
+  L _ (HsPar _ e)
 #else
-unparen (L _ (HsPar _ _ e _)) = e
+  L _ (HsPar _ _ e _)
 #endif
-unparen e = e
+    -- see Note [Sections in HsSyn] in GHC.Hs.Expr
+    | L _ SectionL{} <- e -> expr
+    | L _ SectionR{} <- e -> expr
+    | otherwise -> e
+  _ -> expr
 
 -- | hsExprNeedsParens is not always up-to-date, so this allows us to override
 needsParens :: HsExpr GhcPs -> Bool

--- a/tests/inputs/Parens.test
+++ b/tests/inputs/Parens.test
@@ -8,6 +8,7 @@
 -u Parens.quux 
 -u Parens.blarg
 -u Parens.shl1
+--adhoc "forall a. a . id = a"
 --type-forward Parens.Fn
 --type-forward Parens.MaybeInt
 ===
@@ -64,6 +65,10 @@
  
  shl1 :: Int -> Int
  shl1 n = n `shiftL` 1
+ 
+ shl2 :: Int -> Int
+-shl2 = (`shiftL` 2) . id
++shl2 = (`shiftL` 2)
  
  shl3 :: Int -> Int
 -shl3 n = shl1 n `shiftL` 2


### PR DESCRIPTION
According to Note [Sections in HsSyn] in GHC.Hs.Expr, sections should always appear wrapped in an HsPar, the pretty-printing won't add parentheses otherwise and can lead to malformed output.

Closes #35