### PR TITLE
Add pointer to new github repo to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+# Repository Archived
+
+This repository was archived on July 1st, 2025 and is now read-only.
+
+Development of retrie is continuing at https://github.com/xich/retrie
+
+===
+
 Retrie is a powerful, easy-to-use codemodding tool for Haskell. 
 
 # Install


### PR DESCRIPTION
I noticed the repository is archived, and would like to continue development under my personal github (I am the original author of retrie). This commit adds a pointer to the README, so anyone visiting this repo on Github can find the new repository.